### PR TITLE
Add a new exported setter for the auth token field

### DIFF
--- a/client.go
+++ b/client.go
@@ -106,6 +106,11 @@ func NewClient(apiKey, apiSecret string, options ...ClientOption) (*Client, erro
 	return client, nil
 }
 
+// SetToken sets the auth token.
+func (c *Client) SetToken(token string) {
+	c.authToken = token
+}
+
 // SetClient sets a new underlying HTTP client.
 func (c *Client) SetClient(client *http.Client) {
 	c.HTTP = client


### PR DESCRIPTION
The NewClient method creates a server token and with that token, the messages won't get moderated. With this change, the CreateToken method can be called with the sender user and that token can be set to the client. This way the messages will be moderated.