### PR TITLE
Fix ExportUserResponse

### DIFF
--- a/user.go
+++ b/user.go
@@ -232,8 +232,10 @@ func (c *Client) CreateGuestUser(ctx context.Context, user *User) (*GuestUserRes
 }
 
 type ExportUserResponse struct {
-	*User
-	Response
+	User      *User       `json:"user"`
+	Messages  []*Message  `json:"messages"`
+	Reactions []*Reaction `json:"reactions"`
+	Duration  string      `json:"duration"`
 }
 
 // ExportUser exports the user with the given target user ID.


### PR DESCRIPTION
Fix ExportUserResponse struct to match the exact structure to the response of the GET /users/{user_id}/export endpoint